### PR TITLE
feat: Add support for Azure Container Registry authentication

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,6 +53,8 @@ pub enum Error {
   ReferenceParse(#[from] crate::reference::ReferenceParseError),
   #[error("requested operation requires that credentials are available")]
   NoCredentials,
+  #[error("did not receive auth token")]
+  NoTokenReceived,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
## Description
- Add support for Azure Container Registry authentication

## Motivation and Context
- Ref and credit https://github.com/camallo/dkregistry-rs/pull/263

> As described in https://github.com/camallo/dkregistry-rs/issues/262 Azure Container Registry returns the access token using the access_token field instead of the token field. With this commit, the token could be fetched from both fields

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
