### PR TITLE
feat: Add support for `*.k8s.io` registries q value

### DIFF
--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -102,7 +102,10 @@ impl Config {
 
     let accepted_types = match self.accepted_types {
       Some(a) => a,
-      None => match self.index == "gcr.io" || self.index.ends_with(".gcr.io") {
+      None => match self.index == "gcr.io"
+                || self.index.ends_with(".gcr.io")
+                || self.index.ends_with(".k8s.io")
+            {
         false => vec![
           // accept header types and their q value, as documented in
           // https://tools.ietf.org/html/rfc7231#section-5.3.2
@@ -115,6 +118,7 @@ impl Config {
         // GCR incorrectly parses `q` parameters, so we use special Accept for it.
         // Bug: https://issuetracker.google.com/issues/159827510.
         // TODO: when bug is fixed, this workaround should be removed.
+        // *.k8s.io container registries use GCR and are similarly affected.
         true => vec![
           (MediaTypes::ManifestV2S2, None),
           (MediaTypes::ManifestV2S1Signed, None),

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -102,10 +102,7 @@ impl Config {
 
     let accepted_types = match self.accepted_types {
       Some(a) => a,
-      None => match self.index == "gcr.io"
-                || self.index.ends_with(".gcr.io")
-                || self.index.ends_with(".k8s.io")
-            {
+      None => match self.index == "gcr.io" || self.index.ends_with(".gcr.io") || self.index.ends_with(".k8s.io") {
         false => vec![
           // accept header types and their q value, as documented in
           // https://tools.ietf.org/html/rfc7231#section-5.3.2

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -331,6 +331,7 @@ mod tests {
   #[test_case("not-gcr.io" => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4,application/vnd.docker.distribution.manifest.list.v2+json; q=0.5,application/vnd.oci.image.manifest.v1+json; q=0.5,application/vnd.oci.image.index.v1+json; q=0.5"; "Not gcr registry")]
   #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json"; "gcr.io")]
   #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json"; "Custom gcr.io registry")]
+  #[test_case("foobar.k8s.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json"; "Custom k8s.io registry")]
   fn gcr_io_accept_headers(registry: &str) -> String {
     let client_builder = Client::configure().registry(registry);
     let client = client_builder.build().unwrap();


### PR DESCRIPTION
## Description
- Add support for `*.k8s.io` registries

## Motivation and Context
- Ref and credit https://github.com/camallo/dkregistry-rs/pull/238

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
