### PR TITLE
chore: Update `bytes` and `thiserror` dependencies to latest minor version

### DIFF
--- a/.github/workflows/ci-private.yml
+++ b/.github/workflows/ci-private.yml
@@ -14,7 +14,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.70.0"  # MSRV
+          - "1.71.1"  # MSRV
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.70.0"  # MSRV
+          - "1.71.1"  # MSRV
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.70.0"  # MSRV
+          - "1.71.1"  # MSRV
         include:
           - rust: nightly
             experimental: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,16 +38,16 @@ tar = "0.4"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
 sha2 = "0.10"
-bytes = "1.7"
+bytes = "1.9"
 pin-project = "1.1"
 async-stream = "0.3"
-thiserror = "1.0"
+thiserror = "2.0"
 url = "2.5"
 
 [dev-dependencies]
 dirs = "5.0"
-hyper = "1.4"
-mockito = "1.5"
+hyper = "1.5"
+mockito = "1.6"
 native-tls = "0.2"
 test-case = "3.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-registry"
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 version = "0.6.0"
 authors = [
   "Luca Bruno <lucab@debian.org>",

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -96,14 +96,8 @@ fn parse_link(hdr: Option<&header::HeaderValue>) -> Option<String> {
   // TODO(lucab): this a brittle string-matching parser. Investigate
   // whether there is a a common library to do this, in the future.
 
-  // Raw Header value bytes.
-  let hval = match hdr {
-    Some(v) => v,
-    None => return None,
-  };
-
   // Header value string.
-  let sval = match hval.to_str() {
+  let sval = match hdr?.to_str() {
     Ok(v) => v.to_owned(),
     _ => return None,
   };


### PR DESCRIPTION
- Update `bytes` and `thiserror` dependencies to latest minor version
- Bump MSRV from `1.70.0` to `1.71.1` for new crate versions